### PR TITLE
Ensure website domain wraps below Twitter handle

### DIFF
--- a/source/stylesheets/_components.attendees.scss
+++ b/source/stylesheets/_components.attendees.scss
@@ -141,6 +141,7 @@
 
     @include ellipsis();
     max-width: rem(180);
+    display: inline-block;
 
   }
 


### PR DESCRIPTION
If the Twitter handle was short, the website domain would not necessarily wrap to where it should do.